### PR TITLE
Fix NimBLE-Arduino version

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -18,7 +18,7 @@ extra_configs =
 platform = espressif32
 framework = arduino
 lib_deps = 
-	h2zero/NimBLE-Arduino @ ^2.2.3
+	h2zero/NimBLE-Arduino @ 2.2.3
 	yiannisbourkelis/Uptime Library @ ^1.0.0
 	evert-arias/EasyButton @ 2.0.1
 	arkhipenko/TaskScheduler @ ^3.8.5


### PR DESCRIPTION
The latest versions of h2zero/NimBLE-Arduino library causes build issues due to address allocation conflict.

So, i fixed version to 2.2.3.